### PR TITLE
Add 2D physics layers for Player and Entities. Make Player 'hit' Enemy.

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -58,8 +58,9 @@ action_dash={
 
 [layer_names]
 
-2d_physics/layer_1="Player"
-2d_physics/layer_2="World"
+2d_physics/layer_1="World"
+2d_physics/layer_2="Player"
+2d_physics/layer_3="Entity"
 
 [rendering]
 

--- a/scenes/actors/enemys/sample_enemy.tscn
+++ b/scenes/actors/enemys/sample_enemy.tscn
@@ -19,7 +19,7 @@ size = Vector2(32, 32)
 radius = 17.1172
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_3jojp"]
-radius = 19.0263
+radius = 24.0
 
 [sub_resource type="SpriteFrames" id="SpriteFrames_obo6d"]
 animations = [{
@@ -33,23 +33,23 @@ animations = [{
 }]
 
 [node name="Enemy" type="CharacterBody2D"]
-collision_layer = 4
-collision_mask = 17
+collision_layer = 0
 script = ExtResource("1_obo6d")
 
 [node name="Colider" type="CollisionShape2D" parent="."]
 shape = SubResource("RectangleShape2D_sef37")
 
 [node name="HitBox" type="Area2D" parent="."]
-collision_layer = 8
-collision_mask = 16
+visible = false
+collision_layer = 0
+collision_mask = 2
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="HitBox"]
 shape = SubResource("CircleShape2D_uw10j")
 debug_color = Color(0, 1, 0, 0.419608)
 
 [node name="HurtBox" type="Area2D" parent="."]
-collision_layer = 0
+collision_layer = 4
 collision_mask = 0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="HurtBox"]
@@ -88,8 +88,3 @@ script = ExtResource("7_uw10j")
 
 [node name="OnJump" type="Node" parent="StateMachine"]
 script = ExtResource("8_3jojp")
-
-[connection signal="body_entered" from="HitBox" to="." method="_on_hit_box_body_entered"]
-[connection signal="body_exited" from="HitBox" to="." method="_on_hit_box_body_exited"]
-[connection signal="body_entered" from="HurtBox" to="." method="_on_hurt_box_body_entered"]
-[connection signal="body_exited" from="HurtBox" to="." method="_on_hurt_box_body_exited"]

--- a/scenes/actors/player/player.gd
+++ b/scenes/actors/player/player.gd
@@ -62,3 +62,7 @@ func _can_try_dash() -> bool:
 		return false
 
 	return is_dashing and _dash.can_dash()
+
+
+func _on_hit_box_area_entered(_area: Area2D) -> void:
+	print("Enemy Was Hurt!")

--- a/scenes/actors/player/player.tscn
+++ b/scenes/actors/player/player.tscn
@@ -27,15 +27,14 @@ animations = [{
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_14nni"]
 size = Vector2(32, 32)
 
+[sub_resource type="CircleShape2D" id="CircleShape2D_hcvpp"]
+radius = 24.0
+
 [sub_resource type="CircleShape2D" id="CircleShape2D_inh5e"]
 radius = 20.025
 
-[sub_resource type="CircleShape2D" id="CircleShape2D_hcvpp"]
-radius = 26.0768
-
 [node name="Player" type="CharacterBody2D"]
-collision_layer = 2
-collision_mask = 9
+collision_layer = 0
 script = ExtResource("1_xn4dn")
 
 [node name="AnimatedSprite" type="AnimatedSprite2D" parent="."]
@@ -45,21 +44,21 @@ sprite_frames = SubResource("SpriteFrames_eo4ny")
 shape = SubResource("RectangleShape2D_14nni")
 debug_color = Color(0, 1, 0.972549, 0.419608)
 
-[node name="HurtBox" type="Area2D" parent="."]
-collision_layer = 16
-collision_mask = 8
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="HurtBox"]
-shape = SubResource("CircleShape2D_inh5e")
-
 [node name="HitBox" type="Area2D" parent="."]
-position = Vector2(3, 1)
 collision_layer = 0
-collision_mask = 0
+collision_mask = 4
+monitorable = false
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="HitBox"]
 shape = SubResource("CircleShape2D_hcvpp")
 debug_color = Color(1.8049e-06, 0.540633, 9.62615e-08, 0.419608)
+
+[node name="HurtBox" type="Area2D" parent="."]
+collision_layer = 2
+collision_mask = 0
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="HurtBox"]
+shape = SubResource("CircleShape2D_inh5e")
 
 [node name="PlayerController" type="Node" parent="."]
 script = ExtResource("3_xioh4")
@@ -91,7 +90,4 @@ script = ExtResource("10_84s2a")
 [node name="OnDash" type="Node" parent="StateMachine"]
 script = ExtResource("8_bqf0a")
 
-[connection signal="body_entered" from="HurtBox" to="." method="_on_hurt_box_body_entered"]
-[connection signal="body_exited" from="HurtBox" to="." method="_on_hurt_box_body_exited"]
-[connection signal="body_entered" from="HitBox" to="." method="_on_hit_box_body_entered"]
-[connection signal="body_exited" from="HitBox" to="." method="_on_hit_box_body_exited"]
+[connection signal="area_entered" from="HitBox" to="." method="_on_hit_box_area_entered"]

--- a/scenes/tests/test_player.tscn
+++ b/scenes/tests/test_player.tscn
@@ -18,15 +18,15 @@ size = Vector2(32, 256)
 
 [node name="Node2D" type="Node2D"]
 
-[node name="Camera2D" type="Camera2D" parent="."]
-position = Vector2(-2, 428)
+[node name="Player" parent="." instance=ExtResource("1_16x7c")]
+position = Vector2(560, 168)
+
+[node name="Camera2D" type="Camera2D" parent="Player"]
+position = Vector2(0, 1)
 limit_left = -100000
 limit_top = 0
 editor_draw_limits = true
 editor_draw_drag_margin = true
-
-[node name="Player" parent="." instance=ExtResource("1_16x7c")]
-position = Vector2(560, 168)
 
 [node name="TestGround" type="StaticBody2D" parent="."]
 position = Vector2(600, 904)


### PR DESCRIPTION
Layers:
- Layer 1 -> World
- Layer 2 -> Player
- Layer 3 -> Entity

The `World` layer must be assigned to all Solid objects of the scene. The `Player` and `Entity` layers are assigned to the Hit/Hurtboxes of any entities that can interact in any way, even if it isn't an Attack interaction.

Fix: #10